### PR TITLE
Add hexdump dependency and fix issues link

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,14 @@ setuptools.setup(
     keywords = "forward proxy TCP UDP SSL/TLS",
     packages=setuptools.find_packages(),
     project_urls={
-        "Bug Tracker": __url__ + '/íssues',
+        "Bug Tracker": __url__ + '/issues',
         "Documentation": __url__+ '/wiki',
         "Source Code": __url__,
     },
-    install_requires = [ 'pyyaml' ],
+    install_requires = [
+        "pyyaml",
+        "hexdump"
+    ],
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Running pyforwarder from a clean virtualenv gave this error:
```
ModuleNotFoundError: No module named 'hexdump'
```
From pyforwarder/forwarder/tcp/transfer.py, line 25.

I added the hexdump dependency to setup.py, reinstalled, and the issue is resolved.

While editing the file I also noticed that the issues link used a non-ascii character, so I checked and the "Bug Trackers" link on the [package page](https://pypi.org/project/forwarder/) is broken. Changing to the standard "i" character resolves the link.